### PR TITLE
Minor fixups

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,6 +2,5 @@
 <classpath>
 	<classpathentry kind="src" output="bin" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry combineaccessrules="false" kind="src" path="/processing-core"/>
 	<classpathentry kind="output" path="resources/code"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+bin
+tmp
 distribution

--- a/src/template/library/HelloLibrary.java
+++ b/src/template/library/HelloLibrary.java
@@ -35,11 +35,10 @@ import processing.core.*;
  * Make sure you rename this class as well as the name of the example package 'template' 
  * to your own library or tool naming convention.
  * 
- * @example Hello 
- * 
- * (the tag @example followed by the name of an example included in folder 'examples' will
+ * (the tag example followed by the name of an example included in folder 'examples' will
  * automatically include the example in the javadoc.)
  *
+ * @example Hello 
  */
 
 public class HelloLibrary {


### PR DESCRIPTION
Hi,
I fixed three minor issues that were affecting, IMO, the processing template library:
- I've updated .gitignore to also ignore folders bin and tmp; while it is likely each developer has her own .gitignore file, I believe it is better if the template takes care of hiding those folders created during the build process, like you already do with 'distribution'.
- when importing the project in Eclipse, the IDE will flag an error on the whole project. That is caused by a reference to the 'processing-core' codebase that exists in the classpath file. I deleted this reference as not required and confusing when doing the first import: I initially thought Eclipse wasn't seeing the core.jar and similar libs I had added to the project.
- I fixed issue #4 reported on GitHub. You were using the tag @example while describing its usage. This triggered the doclet to search for a file whose name was the explanation text itself (have a look at the error message reported in the ticket). 

All in all, very little stuff.
Thank you for your attention,

Best,
nico
