### PR TITLE
Make examples folder read only in distribution zip

### DIFF
--- a/resources/build.xml
+++ b/resources/build.xml
@@ -308,10 +308,15 @@ ${line}
   		
   		<copy file="${project.dist.version}/tmp/${project.name}/library.properties" tofile="${project.dist.version}/web/download/${project.name}.txt" />
 		        
-		<zip destfile="${project.dist.version}/${project.name}.zip"
-  	       basedir="${project.dist.version}/tmp"
-  	       excludes="**/.DS_Store"
-		/>
+		<zip destfile="${project.dist.version}/${project.name}.zip">
+			<fileset dir="${project.dist.version}/tmp">
+			    <exclude name="**/.DS_Store"/>
+				<exclude name="**/examples/**"/>
+			</fileset>
+			<zipfileset dir="${project.dist.version}/tmp" filemode="444">
+				<include name="**/examples/**"/>
+			</zipfileset>
+		</zip>
 		
         <move file="${project.dist.version}/${project.name}.zip" todir="${project.dist.version}/web/download" />
 		


### PR DESCRIPTION
I wanted to make the `examples` folder in my library read only, like the processing libraries (eg, `serial`), so I added this in. This means that when users try to save on top of the examples, processing will tell them they should save as another file, rather than overriding the example.

Found out how to do it from [stackoverflow](http://stackoverflow.com/questions/36891261/how-do-you-make-a-file-to-read-only-in-an-ant-build) if interested
