### PR TITLE
Fix folder structure in README template

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -23,10 +23,10 @@ The folder structure for Library ##library.name## should be as follows:
 ```
 Processing
   libraries
-    ##library.name##
+    ##project.name##
       examples
       library
-        ##library.name##.jar
+        ##project.name##.jar
       reference
       src
 ```


### PR DESCRIPTION
We should use the tag `project.name` rather than `library.name` to reflect the folder structure generated by ant / `build.xml`.