### PR TITLE
Exclude `core.jar` from sketchbook copies.

### DIFF
--- a/resources/build.xml
+++ b/resources/build.xml
@@ -174,7 +174,10 @@ ${line}
   			<fileset dir="${project.src}"/>
 	  	</copy>
 	  	<copy todir="${project.tmp}/${project.name}/${folder}">
-  			<fileset dir="${project.lib}" excludes="README" />
+  			<fileset dir="${project.lib}">
+				<exclude name="README"/>
+				<exclude name="**/core.jar"/>
+			</fileset>
 	  	</copy>
 	</target>
 	

--- a/resources/build.xml
+++ b/resources/build.xml
@@ -132,7 +132,9 @@ ${line}
 		<delete dir="${sketchbook.location}/${folder}/${project.name}" />
   	  	<mkdir dir="${sketchbook.location}/${folder}/${project.name}" />
   		<copy todir="${sketchbook.location}/${folder}/${project.name}">
-  			<fileset dir="${project.tmp}/${project.name}"/>
+  			<fileset dir="${project.tmp}/${project.name}">
+				<exclude name="**/core.jar"/>
+			</fileset>
   		</copy> 
 	</target>
 	


### PR DESCRIPTION
Starting with Processing 4, the IDE will refuse to load a sketchbook library if it contains the `core.jar`.

Zipped versions are unaffected since they didn't contain the file anyways, but it makes it a pain to develop with.

Here is the error that is shown:
```
The library "${project.name}" cannot be used
because it contains the processing.core libraries.
Please contact the library author for an update.
```
![image](https://user-images.githubusercontent.com/25164338/150750420-7c96a618-8933-4e57-8e74-d95df0b6dd29.png)