### PR TITLE
Update library.properties to move problematic placed comments

### DIFF
--- a/resources/library.properties
+++ b/resources/library.properties
@@ -37,15 +37,18 @@ paragraph = ##library.paragraph##
 # same syntax as for authors. 
 # That is, [here is a link to Processing](http://processing.org/)
 
-# A version number that increments once with each release. This is used to 
-# compare different versions of the same Library, and check if an update is 
+# A version number that increments once with each release.
+# This must be parsable as an int. It is used to  compare
+# different versions of the same Library, and check if an update is 
 # available. You should think of it as a counter, counting the total number of 
 # releases you've had.
-version = ##library.version##  # This must be parsable as an int
 
-# The version as the user will see it. If blank, the version attribute will be 
+version = ##library.version##
+
+# The version as the user will see it.
+# This is treated as a String. If blank, the version attribute will be 
 # used here. This should be a single word, with no spaces.
-prettyVersion = ##library.prettyVersion##  # This is treated as a String
+prettyVersion = ##library.prettyVersion##
 
 # The min and max revision of Processing compatible with your Library.
 # Note that these fields use the revision and not the version of Processing, 


### PR DESCRIPTION
Remove comments written directly after the 'version' and 'prettyVersion' properties which would otherwise conflict with Processing reading the library version.